### PR TITLE
Rename `coin_balance` column to `balance`

### DIFF
--- a/src/main/kotlin/com/mattrition/qmart/user/BalanceService.kt
+++ b/src/main/kotlin/com/mattrition/qmart/user/BalanceService.kt
@@ -23,7 +23,7 @@ class BalanceService(
                 throw NotFoundException("User ID not found: $userId")
             }
 
-        return user.coinBalance
+        return user.balance
     }
 
     /**
@@ -41,9 +41,9 @@ class BalanceService(
                 throw NotFoundException("User ID not found: $userId")
             }
 
-        user.coinBalance += amount
+        user.balance += amount
 
-        return user.coinBalance
+        return user.balance
     }
 
     /**
@@ -62,14 +62,14 @@ class BalanceService(
                 throw NotFoundException("User ID not found: $userId")
             }
 
-        if (user.coinBalance < amount) {
+        if (user.balance < amount) {
             throw ForbiddenException(
-                "User ${user.username} has insufficient funds: ${user.coinBalance} < $amount",
+                "User ${user.username} has insufficient funds: ${user.balance} < $amount",
             )
         }
 
-        user.coinBalance -= amount
-        return user.coinBalance
+        user.balance -= amount
+        return user.balance
     }
 
     /**
@@ -102,8 +102,8 @@ class BalanceService(
             userRepository.findById(userId).orElseThrow {
                 throw NotFoundException("User ID not found: $userId")
             }
-        user.coinBalance = balance
+        user.balance = balance
 
-        return user.coinBalance
+        return user.balance
     }
 }

--- a/src/main/kotlin/com/mattrition/qmart/user/User.kt
+++ b/src/main/kotlin/com/mattrition/qmart/user/User.kt
@@ -18,7 +18,7 @@ import java.util.UUID
  * @property passwordHash Encrypted password.
  * @property createdAt Date this user was created.
  * @property email
- * @property coinBalance How many coins this user has.
+ * @property balance How much money the user has.
  * @property role Privilege level of the user (user, moderator, admin).
  */
 @Entity
@@ -33,6 +33,6 @@ data class User(
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val email: String? = null,
-    @Column(name = "coin_balance", nullable = false) var coinBalance: BigDecimal = BigDecimal(1000),
+    @Column(nullable = false) var balance: BigDecimal = BigDecimal(1000),
     @Column(nullable = false) val role: String = UserRole.USER.lowercase(),
 )

--- a/src/main/kotlin/com/mattrition/qmart/user/UserService.kt
+++ b/src/main/kotlin/com/mattrition/qmart/user/UserService.kt
@@ -61,7 +61,7 @@ class UserService(
             username = this.username,
             email = this.email,
             createdAt = this.createdAt,
-            coinBalance = this.coinBalance,
+            coinBalance = this.balance,
             role = this.role,
         )
 }

--- a/src/main/resources/db/migration/V4__CoinBalance_Rename.sql
+++ b/src/main/resources/db/migration/V4__CoinBalance_Rename.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    RENAME COLUMN coin_balance TO balance;

--- a/src/test/kotlin/com/mattrition/qmart/order/OrderControllerTest.kt
+++ b/src/test/kotlin/com/mattrition/qmart/order/OrderControllerTest.kt
@@ -124,7 +124,7 @@ class OrderControllerTest : BaseH2Test() {
             )
 
             val sampleOrder = orderWithAddress(TestUsers.user.id!!, BigDecimal(5000))
-            TestUsers.user.coinBalance shouldBeLessThan BigDecimal(5000)
+            TestUsers.user.balance shouldBeLessThan BigDecimal(5000)
 
             mockRequest(
                 requestType = POST,
@@ -171,7 +171,7 @@ class OrderControllerTest : BaseH2Test() {
             userCartItems() shouldHaveSize 2
 
             // Ensure we have enough to buy the items
-            var initialBalance = getTestUser().coinBalance.shouldNotBeNull()
+            var initialBalance = getTestUser().balance.shouldNotBeNull()
             if (initialBalance < BigDecimal(450)) {
                 initialBalance = balanceService.setBalance(TestUsers.user.id!!, BigDecimal(1000))
             }
@@ -192,7 +192,7 @@ class OrderControllerTest : BaseH2Test() {
 
             // Money deducted
             val newBalance = initialBalance - sampleOrder.totalPaid
-            getTestUser().coinBalance shouldBeEqual newBalance
+            getTestUser().balance shouldBeEqual newBalance
 
             // User has 1 order
             val userOrders = orderRepository.findOrdersByBuyerId(TestUsers.user.id!!)


### PR DESCRIPTION
Renames the `coin_balance` column for the **users** table to `balance` for clarity.