### PR TITLE
Remove in-development badge for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
     A Spring Boot API service that powers the core features of Quantum Mart.
 </p>
 
-<p align="center">
-    <img src="https://img.shields.io/badge/status-in_development-blue" />
-</p>
-
 ## Table of Contents
 - [Architecture Summary](#architecture-summary)
 - [API Overview](#api-overview)


### PR DESCRIPTION
As we make it to 1.0, we can remove the "in development" badge.