### PR TITLE
Permission fix in release builder workflows

### DIFF
--- a/.github/workflows/major-release-builder.yml
+++ b/.github/workflows/major-release-builder.yml
@@ -2,6 +2,7 @@ name: Create Major Release
 
 permissions:
   contents: write
+  issues: write
 
 on: workflow_dispatch
 

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -2,6 +2,7 @@ name: Create Release
 
 permissions:
   contents: write
+  issues: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The workflows for creating releases needs the `issues: write` permission to label issues.